### PR TITLE
feat: README template

### DIFF
--- a/_common/README
+++ b/_common/README
@@ -1,6 +1,5 @@
-# README Template for ory/examples
-
-Use the following template for all READMEs in ory/examples.
+<!-- README Template for ory/examples. -->
+<!-- Use the following template for all READMEs in ory/examples. -->
 
 # Title 
 
@@ -37,5 +36,3 @@ Use the following template for all READMEs in ory/examples.
 Feel free to [open a discussion](https://github.com/ory/examples/discussions/new) to provide feedback or talk about ideas, or [open an issue](https://github.com/ory/examples/issues/new) if you want to add your example to the repository or encounter a bug.
 You can contribute to Ory in many ways, see the [Ory Contributing Guidelines](https://www.ory.sh/docs/ecosystem/contributing) for more information.
 <!-- Optional: Add a personal note or sponsor link from the author here.-->
-
-```

--- a/_common/README
+++ b/_common/README
@@ -10,13 +10,14 @@
 
 <!-- Optional: Add a diagram if using multiple services or a more detailed explanation than in description or links to other relevant resources. -->
 
-### Prerequisites
-
-<!-- Add a list of software needed to run the example, ideally with links to the installation page or installation (e.g. brew) commands. -->
 
 ## Develop
 
 <!-- Add a numbered list of commands needed to run the example locally or with Ory Cloud playground. -->
+
+### Prerequisites
+
+<!-- Add a list of software needed to run the example, ideally with links to the installation page or installation (e.g. brew) commands. -->
 
 ### Environmental Variables
 
@@ -24,7 +25,7 @@
 
 ### Run tests
 
-<!-- Add a numbered list of commands needed to run tests locally. -->
+<!-- Add a list of commands needed to run tests locally. -->
 
 ## Deploy
 
@@ -35,4 +36,5 @@
 
 Feel free to [open a discussion](https://github.com/ory/examples/discussions/new) to provide feedback or talk about ideas, or [open an issue](https://github.com/ory/examples/issues/new) if you want to add your example to the repository or encounter a bug.
 You can contribute to Ory in many ways, see the [Ory Contributing Guidelines](https://www.ory.sh/docs/ecosystem/contributing) for more information.
+
 <!-- Optional: Add a personal note or sponsor link from the author here.-->

--- a/_common/README
+++ b/_common/README
@@ -3,16 +3,16 @@
 
 # Title 
 
-<!--Add one sentence describing the project, usecase and key services used. -->
-<!--Add a link to post on the Ory Blog as well as other platforms (dev.to, ...). -->
+<!-- Add one sentence describing the project, usecase, and key services used. -->
+<!-- Add a link to post on the Ory Blog as well as other platforms (dev.to, ...). -->
 
 ## Overview
 
-<!-- Optional: Add an diagram if using multiple services or a more detailed explanation than in description or links to other relevant resources. -->
+<!-- Optional: Add a diagram if using multiple services or a more detailed explanation than in description or links to other relevant resources. -->
 
 ### Prerequisites
 
-<!--Add a list of software needed to run the example, ideally with links to the installation page or installation (e.g. brew) commands. -->
+<!-- Add a list of software needed to run the example, ideally with links to the installation page or installation (e.g. brew) commands. -->
 
 ## Develop
 
@@ -20,7 +20,7 @@
 
 ### Environmental Variables
 
-<!-- Optional: If needed add instructions on how to use environmental variables. -->
+<!-- Describe needed environment variables + instructions on how to set them up. -->
 
 ### Run tests
 

--- a/_common/README
+++ b/_common/README
@@ -19,6 +19,10 @@ Use the following template for all READMEs in ory/examples.
 
 <!-- Add a numbered list of commands needed to run the example locally or with Ory Cloud playground. -->
 
+### Environmental Variables
+
+<!-- Optional: If needed add instructions on how to use environmental variables. -->
+
 ### Run tests
 
 <!-- Add a numbered list of commands needed to run tests locally. -->

--- a/_common/README
+++ b/_common/README
@@ -1,0 +1,37 @@
+# README Template for ory/examples
+
+Use the following template for all READMEs in ory/examples.
+
+# Title 
+
+<!--Add one sentence describing the project, usecase and key services used. -->
+<!--Add a link to post on the Ory Blog as well as other platforms (dev.to, ...). -->
+
+## Overview
+
+<!-- Optional: Add an diagram if using multiple services or a more detailed explanation than in description or links to other relevant resources. -->
+
+### Prerequisites
+
+<!--Add a list of software needed to run the example, ideally with links to the installation page or installation (e.g. brew) commands. -->
+
+## Develop
+
+<!-- Add a numbered list of commands needed to run the example locally or with Ory Cloud playground. -->
+
+### Run tests
+
+<!-- Add a numbered list of commands needed to run tests locally. -->
+
+## Deploy
+
+<!-- Optional: Add a list of steps needed to use the example with Ory services selfhosted.-->
+<!-- Optional: Add a list of steps needed to use the example with Ory Cloud developer project.-->
+
+## Contribute
+
+Feel free to [open a discussion](https://github.com/ory/examples/discussions/new) to provide feedback or talk about ideas, or [open an issue](https://github.com/ory/examples/issues/new) if you want to add your example to the repository or encounter a bug.
+You can contribute to Ory in many ways, see the [Ory Contributing Guidelines](https://www.ory.sh/docs/ecosystem/contributing) for more information.
+<!-- Optional: Add a personal note or sponsor link from the author here.-->
+
+```


### PR DESCRIPTION
A template for all READMEs in the examples repo. 

This should be the general structure for all READMEs in the repo, so it is easy to navigate the different examples and also easy to add new ones (possibly in an more automated way down the line). 

closes https://github.com/ory/examples/issues/9
